### PR TITLE
use new rstudioapi shim for `reindent` in Positron

### DIFF
--- a/R/rstudioapi.R
+++ b/R/rstudioapi.R
@@ -106,14 +106,7 @@ stream_selection <- function(selection, context, pal, n_lines_orig) {
 
   # reindent the code
   rstudioapi::setSelectionRanges(selection$range, id = context$id)
-  if (is_positron()) {
-    # TODO: this is not public api. we actually want to make a PR to
-    # positron to map reindent -> this_command in the rstudioapi shims (#46)
-    .ps.ui.executeCommand("editor.action.reindentselectedlines")
-  } else {
-    rstudioapi::executeCommand("reindent")
-  }
-
+  rstudioapi::executeCommand("reindent")
 
   rstudioapi::setCursorPosition(selection$range$start)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -51,7 +51,3 @@ interactive <- NULL
 is_valid_role <- function(role) {
   grepl("^[a-zA-Z0-9]+$", role)
 }
-
-is_positron <- function() {
-  Sys.getenv("POSITRON") == "1"
-}


### PR DESCRIPTION
Closes #46.

Not quite ready to go, as the changes from ark haven't made it into the newest Positron release quite yet.